### PR TITLE
Snapshot handling

### DIFF
--- a/src/main/java/org/commonjava/maven/ext/versioning/VersionCalculator.java
+++ b/src/main/java/org/commonjava/maven/ext/versioning/VersionCalculator.java
@@ -222,7 +222,7 @@ public class VersionCalculator
         result += sep + useSuffix;
 
         // tack -SNAPSHOT back on if necessary...
-        if ( snapshot )
+        if ( session.preserveSnapshot() && snapshot )
         {
             result += SNAPSHOT_SUFFIX;
         }

--- a/src/main/java/org/commonjava/maven/ext/versioning/VersioningSession.java
+++ b/src/main/java/org/commonjava/maven/ext/versioning/VersioningSession.java
@@ -16,6 +16,8 @@ public class VersioningSession
 
     public static final String INCREMENT_SERIAL_SUFFIX_SYSPROP = "version.incremental.suffix";
 
+    public static final String VERSION_SUFFIX_SNAPSHOT_SYSPROP = "version.suffix.snapshot";
+
     private static VersioningSession INSTANCE = new VersioningSession();
 
     private MavenExecutionRequest request;
@@ -30,6 +32,8 @@ public class VersioningSession
     private String suffix;
 
     private String incrementSerialSuffix;
+
+    private boolean preserveSnapshot;
 
     private RepositorySystemSession repositorySession;
 
@@ -62,6 +66,7 @@ public class VersioningSession
 
         suffix = userProps.getProperty( VERSION_SUFFIX_SYSPROP );
         incrementSerialSuffix = userProps.getProperty( INCREMENT_SERIAL_SUFFIX_SYSPROP );
+        preserveSnapshot = Boolean.parseBoolean( userProps.getProperty( VERSION_SUFFIX_SNAPSHOT_SYSPROP ) );
 
         this.enabled = pom != null && !markerFile.exists() && incrementSerialSuffix != null || suffix != null;
     }
@@ -79,6 +84,11 @@ public class VersioningSession
     public String getSuffix()
     {
         return suffix;
+    }
+
+    public boolean preserveSnapshot()
+    {
+        return preserveSnapshot;
     }
 
     public boolean isEnabled()

--- a/src/test/java/org/commonjava/maven/ext/versioning/VersioningCalculatorTest.java
+++ b/src/test/java/org/commonjava/maven/ext/versioning/VersioningCalculatorTest.java
@@ -231,6 +231,7 @@ public class VersioningCalculatorTest
 
         final String s = "foo-2";
         props.setProperty( VersioningSession.VERSION_SUFFIX_SYSPROP, s );
+        props.setProperty( VersioningSession.VERSION_SUFFIX_SNAPSHOT_SYSPROP, "true" );
         setupSession( props );
 
         final String v = "1.2.GA";
@@ -248,6 +249,7 @@ public class VersioningCalculatorTest
 
         final String s = "foo-2";
         props.setProperty( VersioningSession.VERSION_SUFFIX_SYSPROP, s );
+        props.setProperty( VersioningSession.VERSION_SUFFIX_SNAPSHOT_SYSPROP, "true" );
         setupSession( props );
 
         final String v = "1.2.GA";
@@ -256,6 +258,23 @@ public class VersioningCalculatorTest
 
         final String result = calculate( v + os + sn );
         assertThat( result, equalTo( v + "-" + s + sn ) );
+    }
+
+    @Test
+    public void applySuffixReplaceSNAPSHOT()
+        throws Exception
+    {
+        final Properties props = new Properties();
+
+        final String s = "foo";
+        props.setProperty( VersioningSession.INCREMENT_SERIAL_SUFFIX_SYSPROP, s );
+        setupSession( props );
+
+        final String originalVersion = "1.0.0.Final-foo-SNAPSHOT";
+        final String calcdVersion = "1.0.0.Final-foo-1";
+
+        final String result = calculate( originalVersion );
+        assertThat( result, equalTo( calcdVersion ) );
     }
 
     @Test


### PR DESCRIPTION
Handle when the auto-increment suffix is set to something like "foo" instead of "foo-1"
Add new property to re-append the -SNAPSHOT qualifier to the version string in some cases.
